### PR TITLE
Run multiple steps at once

### DIFF
--- a/constraintsolving/Readme.md
+++ b/constraintsolving/Readme.md
@@ -58,6 +58,13 @@ For instance this command will run the `generate_scores` step
 python main.py --project-dir output/abhinavkumarl-bidding-system/ --single-step generate_scores --query-type Xss --query-name DomBasedXssWorse run
 ```
 
+Also, you can run multiple steps at once with the following command:
+
+```bash
+# Execute multiple steps (also works for just one):
+python main.py --project-dir output/abhinavkumarl-bidding-system/ --steps optimize,generate_scores --query-type Xss --query-name DomBasedXssWorse run
+```
+
 Additionally, a set of databases can be processed (either a single step or all steps) by using the option `--projects-list`. For instance:
 
 ```bash

--- a/constraintsolving/main.py
+++ b/constraintsolving/main.py
@@ -30,7 +30,10 @@ parser = argparse.ArgumentParser()
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s\t%(asctime)s] %(name)s\t%(message)s")
 
 parser.add_argument("--single-step", dest="single_step", type=str, default=all_steps, metavar="STEP",
-                    help="Runs a single step of the orchestrator named STEP")
+                    help="DEPRECATED. USE --steps. Runs a single step of the orchestrator named STEP")
+
+parser.add_argument("--steps", dest="steps", type=str, default=all_steps, metavar="STEPS",
+                    help="Runs all orchestrator steps in the comma-separated list STEPS")
 
 parser.add_argument("--project-dir", dest="project_dir", required=True, type=str,
                     help="Directory of the CodeQL database")
@@ -105,7 +108,11 @@ if __name__ == '__main__':
                             scores_file, no_flow)
 
         if parsed_arguments.command == "run":
-            if parsed_arguments.single_step == all_steps:
+            if parsed_arguments.steps != "":
+                # This should be the new `--steps` argument. --single-step should be deprecated
+                steps_to_run = parsed_arguments.steps.split(",")
+                orchestrator.run_steps(steps_to_run)
+            elif parsed_arguments.single_step == all_steps:
                 orchestrator.run()
             else:
                 orchestrator.run_step(parsed_arguments.single_step) 

--- a/constraintsolving/optimizer/gurobi.py
+++ b/constraintsolving/optimizer/gurobi.py
@@ -11,7 +11,7 @@ from compute_metrics import getallmetrics, createReprPredicate
 from orchestration.steps import OrchestrationStep, Context,\
     CONSTRAINTS_DIR_KEY, MODELS_DIR_KEY, RESULTS_DIR_KEY, WORKING_DIR_KEY, LOGS_DIR_KEY, \
     SOURCE_ENTITIES, SANITIZER_ENTITIES,  SINK_ENTITIES,SRC_SAN_TUPLES_ENTITIES,SAN_SNK_TUPLES_ENTITIES, REPR_MAP_ENTITIES, \
-    SINGLE_STEP_NAME, COMMAND_NAME
+    SINGLE_STEP_NAME, COMMAND_NAME, STEP_NAMES
 
 from solver.config import SolverConfig
 from solver.get_constraints import ConstraintBuilder
@@ -36,9 +36,15 @@ class GenerateModelStep(OrchestrationStep):
             shutil.rmtree(dir_to_remove, onerror=self.clean_error_callback)
 
     def should_use_existing_model_dirs(self, ctx):
+        """This step should use existing model_dirs in the following cases:
+        1. Just running optimize step, should use existing model dirs
+        2. When cleaning, delete the existing model dirs
+        3. If running multiple steps, but this step is not included, reuse existing model dirs
+        """
         return \
             (SINGLE_STEP_NAME in ctx) and ctx[SINGLE_STEP_NAME] == "optimize" or \
-            (COMMAND_NAME in ctx) and ctx[COMMAND_NAME] == "clean"
+            (COMMAND_NAME in ctx) and ctx[COMMAND_NAME] == "clean" or \
+            (STEP_NAMES in ctx) and not self.name() in ctx[STEP_NAMES]
             
 
 

--- a/constraintsolving/orchestration/orchestrator.py
+++ b/constraintsolving/orchestration/orchestrator.py
@@ -5,7 +5,7 @@ from generation.data import DataGenerator, GenerateEntitiesStep, GenerateScoresS
 from optimizer.gurobi import GenerateModelStep, OptimizeStep
 
 from orchestration import global_config
-from orchestration.steps import Context,  RESULTS_DIR_KEY, WORKING_DIR_KEY, SINGLE_STEP_NAME, COMMAND_NAME
+from orchestration.steps import Context,  RESULTS_DIR_KEY, WORKING_DIR_KEY, SINGLE_STEP_NAME, COMMAND_NAME, STEP_NAMES
 
 import time
 import datetime
@@ -94,6 +94,23 @@ class Orchestrator:
             ctx = step.populate(ctx)
             ctx = step.run(ctx)
 
+    def run_steps(self, steps: List[str]):
+        self.logger.info(f"Running orchestration-run steps: {', '.join(steps)}")
+
+        ctx = self.starting_ctx()
+        ctx[COMMAND_NAME] = "run"
+        ctx[STEP_NAMES] = steps
+        
+        for step in self.steps:
+            if step.name() in steps:
+                self.print_step_banner(step, "run")
+                ctx = step.populate(ctx)
+                step.run(ctx)
+            else:
+                # Make each previous step populate the ctx
+                self.logger.info(f"Step `{step.name()}` is populating context")
+                ctx = step.populate(ctx)
+
     def clean(self):
         self.logger.info("Running ALL orchestration-clean steps")
 
@@ -105,6 +122,7 @@ class Orchestrator:
             ctx = step.populate(ctx)
             step.clean(ctx)
 
+    """Deprecated"""
     def run_step(self, step_name: str):
         self.logger.info("Running SINGLE orchestration step")
 

--- a/constraintsolving/orchestration/steps.py
+++ b/constraintsolving/orchestration/steps.py
@@ -25,6 +25,7 @@ LOGS_DIR_KEY = "wd_logs_dir"
 RESULTS_DIR_KEY = "results_dir"
 WORKING_DIR_KEY = "working_dir"
 SINGLE_STEP_NAME = "orchestrator.single_step_name"
+STEP_NAMES = "orchestrator.steps_to_run"
 COMMAND_NAME = "orchestrator.command_name"
 
 


### PR DESCRIPTION
This PR adds the `--steps` flag, which can be used with a comma separated list of steps to run. This should **replace** the `--single-step` flag, since it can be used with one or many steps names.

The orchestrator will run the steps in the normal order, but checking if they are present in the list above.