### PR TITLE
PropagationGraph's points to was not considered literal object declarations

### DIFF
--- a/constraintsolving/examples/points-to-characterization/.gitignore
+++ b/constraintsolving/examples/points-to-characterization/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/constraintsolving/examples/points-to-characterization/index.js
+++ b/constraintsolving/examples/points-to-characterization/index.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const port = 3000;
+
+app.use(express.json());
+
+const appDir = process.env.APP_PATH;
+console.log(`Using appDir=[${appDir}]`);
+
+// For every example:
+// req acts as source, and (parameter 0 (member writeFile (require fs))) as sink
+
+app.post('/simple-aliasing-case', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    fs.writeFile(resolvedPath, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/two-vars-aliasing', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var alisedResolvedPath = resolvedPath;
+    fs.writeFile(alisedResolvedPath, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/object-field-aliasing', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var containerObject = {};
+    containerObject.taintedField = resolvedPath;
+    fs.writeFile(containerObject.taintedField, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/object-field-aliasing-on-init', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var containerObject = {
+        taintedField: resolvedPath,
+    };
+    fs.writeFile(containerObject.taintedField, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/object-field-aliasing-with-var-in-the-middle', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var containerObject = {};
+    containerObject.taintedField = resolvedPath;
+    var aliasedVar = containerObject.taintedField;
+    fs.writeFile(aliasedVar, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/object-field-aliasing-with-tainted-assignment-to-field', (req, res) => {
+    var containerObject = {};
+    containerObject.taintedField = path.join(appDir, req.body.path);
+    var aliasedVar = containerObject.taintedField;
+    fs.writeFile(aliasedVar, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.listen(port, () => {
+    console.log(`Application listenting on port ${port}...`);
+});
+

--- a/constraintsolving/examples/points-to-characterization/index.js
+++ b/constraintsolving/examples/points-to-characterization/index.js
@@ -49,6 +49,32 @@ app.post('/object-field-aliasing', (req, res) => {
     });
 });
 
+app.post('/object-field-aliasing-with-custom-new-object-from-method', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var containerObject = createNewEmptyObject();
+    containerObject.taintedField = resolvedPath;
+    fs.writeFile(containerObject.taintedField, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
+app.post('/object-field-aliasing-with-new-object-from-method', (req, res) => {
+    var resolvedPath =  path.join(appDir, req.body.path);
+    var containerObject = new Object();
+    containerObject.taintedField = resolvedPath;
+    fs.writeFile(containerObject.taintedField, req.body.contents, (err) => {
+        if (err) {
+            res.sendStatus(500);
+        } else {
+            res.sendStatus(200);
+        }
+    });
+});
+
 app.post('/object-field-aliasing-on-init', (req, res) => {
     var resolvedPath =  path.join(appDir, req.body.path);
     var containerObject = {
@@ -94,3 +120,6 @@ app.listen(port, () => {
     console.log(`Application listenting on port ${port}...`);
 });
 
+function createNewEmptyObject() {
+    return {};
+}

--- a/constraintsolving/examples/points-to-characterization/package-lock.json
+++ b/constraintsolving/examples/points-to-characterization/package-lock.json
@@ -1,0 +1,374 @@
+{
+  "name": "seldon-paper",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/constraintsolving/examples/points-to-characterization/package.json
+++ b/constraintsolving/examples/points-to-characterization/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "seldon-paper",
+  "version": "1.0.0",
+  "description": "Seldon Paper examples transribed to NodeJS",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.17.1"
+  }
+}

--- a/javascript/ql/src/TSM/Characterization/Characterization.ql
+++ b/javascript/ql/src/TSM/Characterization/Characterization.ql
@@ -54,6 +54,10 @@ query predicate reprTest(PropagationGraph::Node nd) {
   nd.rep() = "(parameter -1 *)"
 }
 
+query predicate allObjectExpressions(DataFlow::Node nd, string className) {
+  exists(ObjectExpr expr | nd.asExpr() = expr) and nd.getAQlClass() = className
+}
+
 from PropagationGraph::Node src, PropagationGraph::Node snk 
 where 
   src.asDataFlowNode() instanceof RemoteFlowSource and

--- a/javascript/ql/src/TSM/Characterization/Characterization.ql
+++ b/javascript/ql/src/TSM/Characterization/Characterization.ql
@@ -1,0 +1,54 @@
+/**
+ * @name Unsafe shell command constructed from library input
+ * @description Using externally controlled strings in a command line may allow a malicious
+ *              user to change the meaning of the command.
+ * @kind path-problem
+ * @id js/shell-command-constructed-from-input
+ */
+
+import javascript
+import TSM.PropagationGraphs
+
+class CharacterizationConfiguration extends DataFlow::Configuration {
+  CharacterizationConfiguration() { this = "Characterization" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node source) {
+    source instanceof FileSystemWriteAccessParameter
+  }
+}
+
+class FileSystemWriteAccessParameter extends DataFlow::Node {
+  FileSystemWriteAccessParameter() {
+    exists(FileSystemWriteAccess fswa | fswa.getAPathArgument() = this)
+  }
+}
+
+predicate propagationGraphReachable(
+  PropagationGraph::Node source, PropagationGraph::Node destination
+) {
+  // There's a direct floecho Hellow
+  PropagationGraph::edge(source, destination)
+  or
+  // There's a flow through an intermediate node
+  exists(PropagationGraph::Node intermediate |
+    PropagationGraph::edge(source, intermediate) and
+    propagationGraphReachable(intermediate, destination)
+  )
+}
+
+query predicate allPropgraphNodes(PropagationGraph::Node nd) {
+  nd = nd
+}
+
+query predicate allPointsTo(PropagationGraph::Node frm, PropagationGraph::Node to) {
+    PropagationGraph::allPointedBy(frm).(DataFlow::Node) = to.asDataFlowNode()
+}
+
+from PropagationGraph::Node src, PropagationGraph::Node snk 
+where 
+  src.asDataFlowNode() instanceof RemoteFlowSource and
+  snk.asDataFlowNode() instanceof FileSystemWriteAccessParameter and
+  propagationGraphReachable(src, snk)
+select src, "There's a flow-path from $@ to snk",src, snk, snk

--- a/javascript/ql/src/TSM/Characterization/Characterization.ql
+++ b/javascript/ql/src/TSM/Characterization/Characterization.ql
@@ -54,10 +54,6 @@ query predicate reprTest(PropagationGraph::Node nd) {
   nd.rep() = "(parameter -1 *)"
 }
 
-query predicate allObjectExpressions(DataFlow::Node nd, string className) {
-  exists(ObjectExpr expr | nd.asExpr() = expr) and nd.getAQlClass() = className
-}
-
 from PropagationGraph::Node src, PropagationGraph::Node snk 
 where 
   src.asDataFlowNode() instanceof RemoteFlowSource and

--- a/javascript/ql/src/TSM/Characterization/Characterization.ql
+++ b/javascript/ql/src/TSM/Characterization/Characterization.ql
@@ -38,12 +38,20 @@ predicate propagationGraphReachable(
   )
 }
 
-query predicate allPropgraphNodes(PropagationGraph::Node nd) {
-  nd = nd
+query predicate allPropgraphNodes(PropagationGraph::Node nd, string concatRepr) {
+  nd = nd and concatRepr = concat(nd.rep(), "::")
 }
 
-query predicate allPointsTo(PropagationGraph::Node frm, PropagationGraph::Node to) {
-    PropagationGraph::allPointedBy(frm).(DataFlow::Node) = to.asDataFlowNode()
+query predicate allPointsTo(PropagationGraph::Node frm, PropagationGraph::Node to, string reason) {
+  PropagationGraph::pointsTo(_, frm.asDataFlowNode(), reason).(DataFlow::Node) = to.asDataFlowNode()
+}
+
+query predicate allAllocationSites(PropagationGraph::AllocationSite allocationSite) {
+  allocationSite = allocationSite
+}
+
+query predicate reprTest(PropagationGraph::Node nd) {
+  nd.rep() = "(parameter -1 *)"
 }
 
 from PropagationGraph::Node src, PropagationGraph::Node snk 

--- a/javascript/ql/src/TSM/PropagationGraphs.qll
+++ b/javascript/ql/src/TSM/PropagationGraphs.qll
@@ -333,6 +333,10 @@ private int minOcurrences() { result = 1 }
     )
   }
 
+  AllocationSite allPointedBy(Node nd) {    
+    result = pointsTo(_, nd.asDataFlowNode())
+  }
+
   /** Gets the allocation sites `nd` may refer to in context `ctxt`. */
   private AllocationSite pointsTo(Context ctxt, DataFlow::Node nd) {
     viableContext(ctxt, nd) and

--- a/javascript/ql/src/TSM/PropagationGraphs.qll
+++ b/javascript/ql/src/TSM/PropagationGraphs.qll
@@ -290,11 +290,24 @@ private int minOcurrences() { result = 1 }
   class AllocationSite extends DataFlow::Node {
     AllocationSite() {
       getBasicBlock() instanceof ReachableBasicBlock and
-      exists(DataFlow::InvokeNode invk | not calls(invk, _) |
+      exists(DataFlow::InvokeNode invk |
         this = invk
         or
         this = invk.getABoundCallbackParameter(_, _)
-      )
+      ) or
+      this instanceof LiteralObjectNode
+    }
+  }
+
+  /**
+   * A DataFlow::Node that matches a literal object declaration, such as:
+   * ```javascript
+   * const a = {};
+   * ```
+   */
+  private class LiteralObjectNode extends DataFlow::Node {
+    LiteralObjectNode() {
+      this.asExpr() instanceof ObjectExpr
     }
   }
 

--- a/javascript/ql/src/TSM/PropagationGraphs.qll
+++ b/javascript/ql/src/TSM/PropagationGraphs.qll
@@ -268,6 +268,7 @@ private int minOcurrences() { result = 1 }
   pragma[noinline]
   private predicate callInFile(DataFlow::CallNode call, DataFlow::FunctionNode callee, File f) {
     call.getFile() = f and
+    // TODO: This can be improved with TASER info. The `getACallee` candidates
     callee.getFunction() = call.getACallee(_)
   }
 
@@ -286,7 +287,7 @@ private int minOcurrences() { result = 1 }
    * an unresolvable call, or a parameter to a callback function passed as an argument
    * to an unresolvable function
    */
-  private class AllocationSite extends DataFlow::Node {
+  class AllocationSite extends DataFlow::Node {
     AllocationSite() {
       getBasicBlock() instanceof ReachableBasicBlock and
       exists(DataFlow::InvokeNode invk | not calls(invk, _) |
@@ -339,27 +340,32 @@ private int minOcurrences() { result = 1 }
 
   /** Gets the allocation sites `nd` may refer to in context `ctxt`. */
   private AllocationSite pointsTo(Context ctxt, DataFlow::Node nd) {
+    result = pointsTo(ctxt, nd, _)
+  }
+
+  /** Gets the allocation sites `nd` may refer to in context `ctxt`. */
+  AllocationSite pointsTo(Context ctxt, DataFlow::Node nd, string reason) {
     viableContext(ctxt, nd) and
-    result = nd
+    result = nd and reason = "circular"
     or
-    result = pointsTo(ctxt, nd.getAPredecessor())
+    result = pointsTo(ctxt, nd.getAPredecessor()) and reason = "predecessor"
     or
     exists(DataFlow::PropRead pr | nd = pr |
-      result = fieldPointsTo(pointsTo(ctxt, pr.getBase()), pr.getPropertyName())
+      result = fieldPointsTo(pointsTo(ctxt, pr.getBase()), pr.getPropertyName()) and reason = "field"
     )
     or
     // flow from the `i`th argument of a call to the corresponding parameter
     exists(DataFlow::CallNode call, DataFlow::Node arg, Context base |
       argumentPassing(call, arg, nd) and
       ctxt = push(call, base) and
-      result = pointsTo(base, arg)
+      result = pointsTo(base, arg) and reason = "arguement passing"
     )
     or
     // flow from a returned value to a call to the function
     exists(DataFlow::FunctionNode callee |
       calls(nd, callee) and
       viableContext(ctxt, nd) and
-      result = pointsTo(push(nd, ctxt), callee.getAReturn())
+      result = pointsTo(push(nd, ctxt), callee.getAReturn()) and reason = "return"
     )
   }
 


### PR DESCRIPTION
The root cause, as per my understanding, was that literal object declarations, such as:
```javascript
var a = {};
var a = {
  field: ""
};
```
were not considered as allocation sites. Also, function calls that where declared in the same file in which they were called were ignored.

This PR:
- Makes the `AllocationSite` type consider literal object declarations
- Makes the `AllocationSite` type consider function calls to same-file declared functions
- Adds a debugging version of the `PropagationGraph::pointsTo` 
- Adds an example exposing multiple aliasing with object cases